### PR TITLE
[C++] 0.1.3

### DIFF
--- a/cpp/Platform.Delegates/Platform.Delegates.Delegate.h
+++ b/cpp/Platform.Delegates/Platform.Delegates.Delegate.h
@@ -169,8 +169,8 @@ namespace Platform::Delegates
         static bool AreBoundFunctionsEqual(const DelegateFunctionType &left, const DelegateFunctionType &right)
         {
             constexpr size_t size = sizeof(DelegateFunctionType);
-            std::byte leftArray[size] = { {(std::byte)0} };
-            std::byte rightArray[size] = { {(std::byte)0} };
+            std::byte leftArray[size] = {(std::byte)0};
+            std::byte rightArray[size] = {(std::byte)0};
             new (&leftArray) DelegateFunctionType(left);
             new (&rightArray) DelegateFunctionType(right);
             //PrintBytes(leftArray, rightArray, size);

--- a/cpp/Platform.Delegates/Platform.Delegates.TemplateLibrary.nuspec
+++ b/cpp/Platform.Delegates/Platform.Delegates.TemplateLibrary.nuspec
@@ -8,9 +8,10 @@
     <releaseNotes>Refactoring to since C++17 standard.
 Use Delegate constructor with deductions guides instead CreateDelegate function.
 Fixed calling function with rvalue-reference arguments.
+Removing C++20 content.
 First release version for conan.
 </releaseNotes>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
     <authors>konard, poul250, uselessgoddess</authors>
     <owners>konard, poul250, uselessgoddess</owners>
     <copyright>konard, poul250, uselessgoddess</copyright>


### PR DESCRIPTION
Removing C++20 content (GCC 8 is not supported double {{}} initializer operand)