### PR TITLE
Include README.md file in NuGet packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Delegates/issues/26
-Your prepared branch: issue-26-1e0ee9c2
-Your prepared working directory: /tmp/gh-issue-solver-1757729856308
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Delegates/issues/26
+Your prepared branch: issue-26-1e0ee9c2
+Your prepared working directory: /tmp/gh-issue-solver-1757729856308
+
+Proceed.

--- a/cpp/Platform.Delegates/Platform.Delegates.TemplateLibrary.nuspec
+++ b/cpp/Platform.Delegates/Platform.Delegates.TemplateLibrary.nuspec
@@ -15,9 +15,13 @@
     <icon>images/icon.png</icon>
     <tags>C++ Native Delegates Delegate MulticastDelegate</tags>
     <license type="expression">MIT</license>
+    <readme>README.md</readme>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <dependencies>
       <group targetFramework="native"></group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="../../README.md" target="" />
+  </files>
 </package>

--- a/csharp/Platform.Delegates/Platform.Delegates.csproj
+++ b/csharp/Platform.Delegates/Platform.Delegates.csproj
@@ -24,7 +24,12 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <LangVersion>latest</LangVersion>
         <PackageReleaseNotes>Update target framework from net7 to net8.</PackageReleaseNotes>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
       <Nullable>enable</Nullable>
     </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
This PR implements the requirement to include README.md files in NuGet packages for both C# and C++ projects, as requested in issue #26.

## Changes Made
- **C# Project**: Added `PackageReadmeFile` property and included README.md file using MSBuild ItemGroup in `Platform.Delegates.csproj`
- **C++ Project**: Added `<readme>` element in metadata and `<files>` section to include README.md in `Platform.Delegates.TemplateLibrary.nuspec`

## Implementation Details
- Followed Microsoft's documentation for including README files in NuGet packages
- Used relative paths to include the root README.md file in both packages  
- Verified that C# package builds successfully and includes README.md
- Both implementations are compatible with NuGet 5.10.0+ requirements

## Test Plan
- [x] C# package builds successfully with `dotnet pack`
- [x] README.md file is included in the generated .nupkg file
- [x] C++ nuspec file follows proper XML schema for readme inclusion
- [ ] Verify packages display README on NuGet.org when published

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #26